### PR TITLE
docker commit --change requires double quote (") NOT single quote (')

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ docker container exec unruffled_tereshkova ls /tmp
 docker container cp target/hello-world-rest-api.jar 54cf414254e48d5f68c4d468b2dd4cbdd95d17f9e2074fdb9df7f64987697f2b:/tmp
 docker container commit unruffled_tereshkova in28min/hello-world-rest-api:manual 
 docker run -p 8080:8080 in28min/hello-world-rest-api:manual
-docker container commit --change='CMD ["java","-jar","/tmp/hello-world-rest-api.jar"]' unruffled_tereshkova in28min:hello-world-rest-api:manual2
+docker container commit --change="CMD ["java","-jar","/tmp/hello-world-rest-api.jar"]" unruffled_tereshkova in28min:hello-world-rest-api:manual2
 docker run -p 8080:8080 in28min/hello-world-rest-api:manual2
 docker inspect in28min/hello-world-rest-api:dockerfile1
 docker history in28min/hello-world-rest-api:dockerfile1


### PR DESCRIPTION
As specified in docker reference doc: https://docs.docker.com/engine/reference/commandline/commit/#commit-a-container-with-new-configurations

also, someone faced this issue and reported already: https://stackoverflow.com/questions/60008200/docker-commit-requires-at-least-1-and-at-most-2-arguments/62220731#62220731